### PR TITLE
Image Effects to mimic location's yaw AND pitch

### DIFF
--- a/src/main/java/de/slikey/effectlib/util/BaseImageEffect.java
+++ b/src/main/java/de/slikey/effectlib/util/BaseImageEffect.java
@@ -62,6 +62,11 @@ public abstract class BaseImageEffect extends Effect {
      * Should it orient to face the player's direction?
      */
     public boolean orient = true;
+    
+    /**
+     * Should it face in the same direction as the location. Obeying yaw and pitch?
+     */
+    public boolean mimic = false;
 
     /**
      * What plane should it rotate?
@@ -167,6 +172,9 @@ public abstract class BaseImageEffect extends Effect {
                 }
                 if (orient) {
                     VectorUtils.rotateAroundAxisY(v, -location.getYaw() * MathUtils.degreesToRadians);
+                }
+                if (mimic) {
+                    VectorUtils.rotateVector(v, location);   
                 }
                 if (enableRotation) {
                     double rotX = 0;

--- a/src/main/java/de/slikey/effectlib/util/BaseImageEffect.java
+++ b/src/main/java/de/slikey/effectlib/util/BaseImageEffect.java
@@ -173,7 +173,7 @@ public abstract class BaseImageEffect extends Effect {
                 if (orient) {
                     VectorUtils.rotateAroundAxisY(v, -location.getYaw() * MathUtils.degreesToRadians);
                 }
-                if (mimic) {
+                if (orientPitch) {
                     VectorUtils.rotateVector(v, location);   
                 }
                 if (enableRotation) {

--- a/src/main/java/de/slikey/effectlib/util/BaseImageEffect.java
+++ b/src/main/java/de/slikey/effectlib/util/BaseImageEffect.java
@@ -66,7 +66,7 @@ public abstract class BaseImageEffect extends Effect {
     /**
      * Should it face in the same direction as the location. Obeying yaw and pitch?
      */
-    public boolean mimic = false;
+    public boolean orientPitch = false;
 
     /**
      * What plane should it rotate?


### PR DESCRIPTION
Lets the image effect rotate based on the location's yaw AND pitch, instead of how orient rotates (yaw only)

mimic is false by default.